### PR TITLE
fix: request errors and 'spin build' not working.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ http = "0.2"
 # Useful for serialization and deserialization.
 serde = { version = "1.0", features = [ "derive" ] }
 # The Spin SDK.
-spin-sdk = { git = "https://github.com/fermyon/spin", rev = "40714a18a5963eb5c29bcf3643319fbd04dd8cd7" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v0.5.0" }
 # TOML deserializer.
 toml = "0.5"
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
-wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "e9c7c0a3405845cecd3fe06f3c20ab413302fc73" }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
 
 [workspace]

--- a/spin.toml
+++ b/spin.toml
@@ -11,3 +11,5 @@ source = "target/wasm32-wasi/release/url_shortener.wasm"
 files = [ "router.toml" ]
 [component.trigger]
 route = "/..."
+[component.build]
+command = "cargo build --target wasm32-wasi --release"


### PR DESCRIPTION
When attempting to access the addresses, an error parsing the request would occur. Fixed by the first commit.

When calling 'spin build'. A message saying that there's no build file would appear. Fixed on the second commit.